### PR TITLE
chore: replace deprecated Heroku API

### DIFF
--- a/js/detalle.js
+++ b/js/detalle.js
@@ -6,7 +6,7 @@ var botonComprar = document.querySelector("comprar")
 
 
 async function getData(){ 
-    await fetch("https://apipetshop.herokuapp.com/api/articulos") 
+    await fetch("https://mindhub-xj03.onrender.com/api/petshop") 
         .then(response => response.json())
         .then(json => articulos.push(...json.response))
         console.log(articulos)

--- a/js/farmacia.js
+++ b/js/farmacia.js
@@ -7,7 +7,7 @@ var alerta = document.querySelector("#alerta");
 let buscador = document.querySelector("#buscar");
 buscador.addEventListener("keyup", search);
 async function getData() {
-  await fetch("https://apipetshop.herokuapp.com/api/articulos")
+  await fetch("https://mindhub-xj03.onrender.com/api/petshop")
     .then((response) => response.json())
     .then((json) => articulos.push(...json.response));
   medicamentos.push(

--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,7 @@ var imagenes = []
 const modal = document.querySelector("#modal")
 
 async function getData(){ 
-    await fetch("https://apipetshop.herokuapp.com/api/articulos") 
+    await fetch("https://mindhub-xj03.onrender.com/api/petshop") 
         .then(response => response.json())
         .then(json => eventos.push(...json.response))
         console.log(eventos)       

--- a/js/juguetes.js
+++ b/js/juguetes.js
@@ -7,7 +7,7 @@ var alerta = document.querySelector("#alerta");
 let buscador = document.querySelector("#buscar");
 buscador.addEventListener("keyup", search);
 async function getData() {
-  await fetch("https://apipetshop.herokuapp.com/api/articulos")
+  await fetch("https://mindhub-xj03.onrender.com/api/petshop")
     .then((response) => response.json())
     .then((json) => articulos.push(...json.response));
   juguetes.push(...articulos.filter((articulo) => articulo.tipo === "Juguete"));

--- a/js/localstorage.js
+++ b/js/localstorage.js
@@ -6,7 +6,7 @@ var totalprecio = 0
 var contador = 0
 var h1s = document.querySelector("#elh1")
 async function data(){ 
-    await fetch("https://apipetshop.herokuapp.com/api/articulos") 
+    await fetch("https://mindhub-xj03.onrender.com/api/petshop") 
     .then(response => response.json())
     .then(json => items.push(...json.response))
     items.map(items=>{


### PR DESCRIPTION
## Summary
- use mindhub pet shop API instead of deprecated Heroku endpoint

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68940131e5b48325a507e6ca21ff3af5