### PR TITLE
feat: enhance cards with 3D tilt effect

### DIFF
--- a/css/card.css
+++ b/css/card.css
@@ -54,10 +54,11 @@ main {
   box-shadow: 0 1em 2em rgb(0 0 0 / 0.2);
   transition: transform ease 250ms;
   border-radius: 0.5rem;
-  background-color: #fff;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
   min-height: 30rem;
   position: relative;
   overflow: hidden;
+  will-change: transform;
 }
 
 .card:hover {
@@ -88,10 +89,9 @@ main {
   box-shadow: 0 5px 30px 10px rgba(0, 0, 0, 0.3);
 }
 
-.cardImg img {
-  object-position: center;
-  width: 100%;
-  margin-top: 1rem;
+/* Imagenes deshabilitadas para un estilo limpio sin medios */
+.cardImg {
+  display: none;
 }
 
 .stock {

--- a/html/card.html
+++ b/html/card.html
@@ -12,9 +12,6 @@
     <div class="row">
       <div class="example-1 card">
         <div class="wrapper">
-          <div class="imgdentro">
-            <img src="https://puppis.vteximg.com.br/arquivos/ids/157833-1000-1000/Power-Ultra.jpg?v=635852684254630000" alt="">
-          </div>
           <div class="date">
             <span class="year">Stock</span>
             <span class="month">Limitado:</span>
@@ -35,6 +32,15 @@
         </div>
       </div>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.0/vanilla-tilt.min.js"></script>
+    <script>
+      VanillaTilt.init(document.querySelectorAll(".card"), {
+        max: 15,
+        speed: 400,
+        glare: true,
+        "max-glare": 0.2,
+      });
+    </script>
   </body>
 </html>
 

--- a/html/card3.html
+++ b/html/card3.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="../css/card.css" />
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.0/vanilla-tilt.min.js"></script>
     <script defer src="../js/juguetes.js"></script>
     <script defer src="../js/localstorage.js"></script>
     <script
@@ -19,11 +20,6 @@
     <div id="cartas" class="containerGrid">
       <div class="card">
         ${alerta}
-        <div class="cardImg">
-          <a href="./detalle.html?id=${item._id}">
-            <img src="${item.imagen}" alt="" />
-          </a>
-        </div>
         <div class="data">
           <div class="content">
             <p class="title">${item.nombre}</p>
@@ -50,5 +46,13 @@
         </div>
       </div>
     </div>
+    <script>
+      VanillaTilt.init(document.querySelectorAll(".card"), {
+        max: 15,
+        speed: 400,
+        glare: true,
+        "max-glare": 0.2,
+      });
+    </script>
   </body>
 </html>

--- a/html/juguetes.html
+++ b/html/juguetes.html
@@ -339,6 +339,7 @@
         </form>
       </section>
     </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.0/vanilla-tilt.min.js"></script>
     <script src="../js/juguetes.js"></script>
     <script src="../js/localStorage.js"></script>
     <script

--- a/js/juguetes.js
+++ b/js/juguetes.js
@@ -1,5 +1,4 @@
 var articulos = [];
-var imagenes = [];
 var juguetes = [];
 let toDisplay = [];
 let data = [];
@@ -14,7 +13,6 @@ async function getData() {
         ...json.map((item) => ({
           _id: item.id,
           nombre: item.name,
-          imagen: item.photoUrls?.[0] || "",
           descripcion: item.status || item.category?.name || "",
           precio: 0,
           stock: 0,
@@ -48,11 +46,6 @@ function updateDisplay(data) {
     templateHTML += `
       <div class="card">
         ${alerta}
-        <div class="cardImg">
-          <a href="./detalle.html?id=${item._id}">
-            <img src="${item.imagen}" alt="" />
-          </a>
-        </div>
         <div class="data">
           <div class="content">
             <p class="title">
@@ -83,10 +76,18 @@ function updateDisplay(data) {
         </div>
       </div>
 `;
-
-    // console.log(juguetes)
-    document.querySelector("#cartas").innerHTML = templateHTML;
   });
+
+  // Render the cards once and apply tilt effect
+  document.querySelector("#cartas").innerHTML = templateHTML;
+  if (window.VanillaTilt) {
+    VanillaTilt.init(document.querySelectorAll(".card"), {
+      max: 15,
+      speed: 400,
+      glare: true,
+      "max-glare": 0.2,
+    });
+  }
 }
 
 var favorites = JSON.parse(localStorage.getItem("favoritos")) || [];


### PR DESCRIPTION
## Summary
- apply gradient backgrounds and hide card images
- integrate vanilla-tilt for lightweight 3D card effect
- initialize tilt effect on dynamic cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689407b29c788325a031893ba864bdda