### PR TITLE
Fix juguetes page localstorage script path

### DIFF
--- a/html/juguetes.html
+++ b/html/juguetes.html
@@ -341,7 +341,7 @@
     </footer>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.0/vanilla-tilt.min.js"></script>
     <script src="../js/juguetes.js"></script>
-    <script src="../js/localStorage.js"></script>
+    <script src="../js/localstorage.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"


### PR DESCRIPTION
## Summary
- fix casing of localstorage script on juguetes page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68955e9046508325b9ac9588156c72e6