### PR TITLE
Fix cart item display and add placeholder images

### DIFF
--- a/js/farmacia.js
+++ b/js/farmacia.js
@@ -14,8 +14,8 @@ async function getData() {
         ...json.map((item) => ({
           _id: item.id,
           nombre: item.name,
-          imagen: item.photoUrls?.[0] || "",
-          descripcion: item.status || item.category?.name || "",
+          imagen: item.photoUrls?.[0] || 'https://placekitten.com/200/200',
+          descripcion: item.status || item.category?.name || '',
           precio: 0,
           stock: 0,
         }))
@@ -63,7 +63,7 @@ function updateDisplay(data) {
             </p>
             <div class="botones">
               <button
-                onClick="getID('${item._id}')"
+                onClick="getID(${item._id})"
                 id="${item._id}"
                 class="btn btn-primary enviar"
               >
@@ -71,7 +71,7 @@ function updateDisplay(data) {
               </button>
               <a href="./shop.html"
                 ><button
-                  onClick="getID('${item._id}')"
+                  onClick="getID(${item._id})"
                   id="${item._id}"
                   class="btn btn-primary enviar"
                 >
@@ -92,7 +92,7 @@ function updateDisplay(data) {
 var favorites = JSON.parse(localStorage.getItem("favoritos")) || [];
 
 function getID(event) {
-  favorites.push(event);
+  favorites.push(Number(event));
   const unicoFav = new Set(favorites);
   var clearFav = [...unicoFav];
 

--- a/js/juguetes.js
+++ b/js/juguetes.js
@@ -13,7 +13,8 @@ async function getData() {
         ...json.map((item) => ({
           _id: item.id,
           nombre: item.name,
-          descripcion: item.status || item.category?.name || "",
+          imagen: item.photoUrls?.[0] || 'https://placekitten.com/200/200',
+          descripcion: item.status || item.category?.name || '',
           precio: 0,
           stock: 0,
         }))
@@ -56,7 +57,7 @@ function updateDisplay(data) {
             </p>
             <div class="botones">
               <button
-                onClick="getID('${item._id}')"
+                onClick="getID(${item._id})"
                 id="${item._id}"
                 class="btn btn-primary enviar"
               >
@@ -64,7 +65,7 @@ function updateDisplay(data) {
               </button>
               <a href="./shop.html"
                 ><button
-                  onClick="getID('${item._id}')"
+                  onClick="getID(${item._id})"
                   id="${item._id}"
                   class="btn btn-primary enviar"
                 >
@@ -93,7 +94,7 @@ function updateDisplay(data) {
 var favorites = JSON.parse(localStorage.getItem("favoritos")) || [];
 
 function getID(event) {
-  favorites.push(event);
+  favorites.push(Number(event));
   const unicoFav = new Set(favorites);
   var clearFav = [...unicoFav];
 

--- a/js/localstorage.js
+++ b/js/localstorage.js
@@ -17,7 +17,7 @@ async function obtenerItems() {
       ...datos.map((item) => ({
         _id: item.id,
         nombre: item.name,
-        imagen: item.photoUrls?.[0] || '',
+        imagen: item.photoUrls?.[0] || 'https://placekitten.com/200/200',
         descripcion: item.status || item.category?.name || '',
         precio: 0,
         stock: 0,
@@ -31,7 +31,7 @@ async function obtenerItems() {
 }
 
 function cargarIdsGuardados() {
-  return JSON.parse(localStorage.getItem('carrito')) || [];
+  return (JSON.parse(localStorage.getItem('carrito')) || []).map(Number);
 }
 
 function actualizarBadge() {
@@ -60,9 +60,9 @@ function renderizarCarrito() {
           <td class="textomover">${item.nombre}</td>
           <td class="textomover">${item.cantidad}</td>
           <td>
-            <button class="mover botonmas" onClick="sumarArticulo('${item._id}')">+</button>
-            <button class="mover botonborrar" onClick="eliminarArticulo('${item._id}')">Borrar articulo</button>
-            <button class="mover botonmenos" onClick="restarArticulo('${item._id}')">-</button>
+            <button class="mover botonmas" onClick="sumarArticulo(${item._id})">+</button>
+            <button class="mover botonborrar" onClick="eliminarArticulo(${item._id})">Borrar articulo</button>
+            <button class="mover botonmenos" onClick="restarArticulo(${item._id})">-</button>
           </td>
           <td class="textomover">$${subtotal}</td>
         </tr>


### PR DESCRIPTION
## Summary
- Ensure cart renders product details by normalizing stored IDs and updating cart actions
- Assign fallback image URL for items when the API lacks photos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956046cfc88325a0a28436b63926d5