### PR TITLE
Use static placeholder image for all items

### DIFF
--- a/js/detalle.js
+++ b/js/detalle.js
@@ -10,7 +10,7 @@ async function getData() {
         ...json.map((item) => ({
           _id: item.id,
           nombre: item.title,
-          imagen: item.url,
+          imagen: 'https://cdn.pixabay.com/photo/2016/02/19/10/00/dog-1208816_1280.jpg',
           descripcion: item.title,
           precio: (item.id % 100) + 20,
           stock: 10,

--- a/js/farmacia.js
+++ b/js/farmacia.js
@@ -14,7 +14,7 @@ async function getData() {
         ...json.map((item) => ({
           _id: item.id,
           nombre: item.name,
-          imagen: item.photoUrls?.[0] || 'https://placekitten.com/200/200',
+          imagen: 'https://cdn.pixabay.com/photo/2016/02/19/10/00/dog-1208816_1280.jpg',
           descripcion: item.status || item.category?.name || '',
           precio: 0,
           stock: 0,

--- a/js/index.js
+++ b/js/index.js
@@ -8,7 +8,7 @@ async function getData(){
         .then(json => eventos.push(...json.map(item => ({
             _id: item.id,
             nombre: item.name,
-            imagen: item.photoUrls?.[0] || "",
+            imagen: 'https://cdn.pixabay.com/photo/2016/02/19/10/00/dog-1208816_1280.jpg',
             descripcion: item.status || item.category?.name || "",
             precio: 0,
             stock: 0

--- a/js/juguetes.js
+++ b/js/juguetes.js
@@ -13,7 +13,7 @@ async function getData() {
         ...json.map((item) => ({
           _id: item.id,
           nombre: item.name,
-          imagen: item.photoUrls?.[0] || 'https://placekitten.com/200/200',
+          imagen: 'https://cdn.pixabay.com/photo/2016/02/19/10/00/dog-1208816_1280.jpg',
           descripcion: item.status || item.category?.name || '',
           precio: 0,
           stock: 0,

--- a/js/localstorage.js
+++ b/js/localstorage.js
@@ -17,7 +17,7 @@ async function obtenerItems() {
       ...datos.map((item) => ({
         _id: item.id,
         nombre: item.name,
-        imagen: item.photoUrls?.[0] || 'https://placekitten.com/200/200',
+        imagen: 'https://cdn.pixabay.com/photo/2016/02/19/10/00/dog-1208816_1280.jpg',
         descripcion: item.status || item.category?.name || '',
         precio: 0,
         stock: 0,


### PR DESCRIPTION
## Summary
- Replace all API-derived photo URLs with a fixed placeholder image from the internet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956183b5f8832586a5b6af34e7e837